### PR TITLE
Fix documentation generation with docfx

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -207,8 +207,5 @@ jobs:
     - name: Publish CSharp documentation to gh-pages branch
       run: |
         export REPOSITORY_NAME=$(basename ${{ github.repository }})
-        wget "$SCRIPTS_BASE_URL/docfx.json"
-        wget "$SCRIPTS_BASE_URL/filter.yml"
-        wget "$SCRIPTS_BASE_URL/toc.yml"
         wget "$SCRIPTS_BASE_URL/publish-csharp-docs.sh"
         bash ./publish-csharp-docs.sh

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -128,8 +128,5 @@ jobs:
     - name: Publish documentation to gh-pages branch
       run: |
         export REPOSITORY_NAME=$(basename ${{ github.repository }})
-        wget "$SCRIPTS_BASE_URL/docfx.json"
-        wget "$SCRIPTS_BASE_URL/filter.yml"
-        wget "$SCRIPTS_BASE_URL/toc.yml"
         wget "$SCRIPTS_BASE_URL/publish-csharp-docs.sh"
         bash ./publish-csharp-docs.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets.Json/issues/47
-Your prepared branch: issue-47-253142db
-Your prepared working directory: /tmp/gh-issue-solver-1757571492163
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets.Json/issues/47
+Your prepared branch: issue-47-253142db
+Your prepared working directory: /tmp/gh-issue-solver-1757571492163
+
+Proceed.

--- a/docfx.json
+++ b/docfx.json
@@ -1,0 +1,39 @@
+{
+  "metadata": [
+    {
+      "src": [
+        {
+          "files": [ "**/*.sln" ],
+          "exclude": [ "**/bin/**", "**/obj/**" ],
+          "src": "csharp"
+        }
+      ],
+      "dest": "obj/api",
+      "filter": "filter.yml",
+      "properties": { "TargetFramework": "net8" }
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": [ "**/*.yml" ],
+        "src": "obj/api",
+        "dest": "api"
+      },
+      {
+        "files": [ "*.md", "toc.yml" ]
+      }
+    ],
+    "globalMetadata": {
+      "_appTitle": "LinksPlatform's Platform.Data.Doublets.Json Library",
+      "_enableSearch": true,
+      "_gitContribute": {
+        "branch": "main"
+      },
+      "_gitUrlPattern": "github"
+    },
+    "markdownEngineName": "markdig",
+    "dest": "_site",
+    "xrefService": [ "https://xref.docs.microsoft.com/query?uid={uid}" ]
+  }
+}

--- a/filter.yml
+++ b/filter.yml
@@ -1,0 +1,5 @@
+apiRules:
+- exclude:
+    uidRegex: (Tests|Benchmarks)(\.[A-Za-z]+)?$
+- exclude:
+    uidRegex: CSharpToCppTranslator$

--- a/toc.yml
+++ b/toc.yml
@@ -1,0 +1,5 @@
+- name: Home
+  href: README.md
+- name: API Documentation
+  href: obj/api/
+  homepage: api/Platform.Data.Doublets.Json.html


### PR DESCRIPTION
## Summary
This PR fixes the documentation generation with docfx by addressing several configuration issues:

- **Target Framework Mismatch**: Updated `docfx.json` to use `net8` instead of `netstandard2.0` to match the actual project target framework
- **Source Directory**: Configured docfx to look for `.sln` files in the correct `csharp/` subdirectory
- **Git Branch Reference**: Changed branch reference from `master` to `main` to match the repository's default branch
- **Local Configuration Files**: Added properly configured `docfx.json`, `filter.yml`, and `toc.yml` to the repository instead of downloading them from remote scripts
- **Workflow Updates**: Modified GitHub Actions workflows to use local configuration files, eliminating potential configuration mismatches

## Test plan
- [x] Verified documentation generation works locally with `docfx docfx.json`
- [x] Confirmed all API documentation files are generated correctly in `_site/api/`
- [x] Validated proper filtering of test and benchmark assemblies
- [x] Tested correct API links in table of contents

The documentation now generates successfully without errors, and the workflows will use consistent, version-controlled configuration files.

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #47