### PR TITLE
Replace Platform.Numbers library with .NET 8 generic math

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets.Json/issues/46
-Your prepared branch: issue-46-9e397f50
-Your prepared working directory: /tmp/gh-issue-solver-1757571999922
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets.Json/issues/46
+Your prepared branch: issue-46-9e397f50
+Your prepared working directory: /tmp/gh-issue-solver-1757571999922
+
+Proceed.

--- a/csharp/Platform.Data.Doublets.Json/DefaultJsonStorage.cs
+++ b/csharp/Platform.Data.Doublets.Json/DefaultJsonStorage.cs
@@ -1,4 +1,4 @@
-using Platform.Numbers;
+using System.Numerics;
 using Platform.Data.Doublets.Unicode;
 using Platform.Data.Doublets.Sequences.Converters;
 using Platform.Data.Doublets.CriterionMatchers;
@@ -25,7 +25,7 @@ namespace Platform.Data.Doublets.Json
     /// </summary>
     /// <seealso cref="IJsonStorage{TLinkAddress}"/>
     public class DefaultJsonStorage<TLinkAddress> : IJsonStorage<TLinkAddress>
-        where TLinkAddress : struct
+        where TLinkAddress : struct, INumber<TLinkAddress>
     {
         /// <summary>
         /// <para>
@@ -47,7 +47,7 @@ namespace Platform.Data.Doublets.Json
         /// </para>
         /// <para></para>
         /// </summary>
-        public static readonly TLinkAddress One = Arithmetic.Increment(Zero);
+        public static readonly TLinkAddress One = Zero + TLinkAddress.One;
         /// <summary>
         /// <para>
         /// The balanced variant converter.
@@ -279,21 +279,36 @@ namespace Platform.Data.Doublets.Json
             Any = Links.Constants.Any;
             var typeAddress = One;
             Type = links.GetOrCreate(typeAddress, typeAddress);
-            var unicodeSymbolType = links.GetOrCreate(Type, Arithmetic.Increment(ref typeAddress));
-            var unicodeSequenceType = links.GetOrCreate(Type, Arithmetic.Increment(ref typeAddress));
-            DocumentType = links.GetOrCreate(Type, Arithmetic.Increment(ref typeAddress));
-            ObjectType = links.GetOrCreate(Type, Arithmetic.Increment(ref typeAddress));
-            MemberType = links.GetOrCreate(Type, Arithmetic.Increment(ref typeAddress));
-            ValueType = links.GetOrCreate(Type, Arithmetic.Increment(ref typeAddress));
-            StringType = links.GetOrCreate(Type, Arithmetic.Increment(ref typeAddress));
-            EmptyStringType = links.GetOrCreate(Type, Arithmetic.Increment(ref typeAddress));
-            NumberType = links.GetOrCreate(Type, Arithmetic.Increment(ref typeAddress));
-            NegativeNumberType = links.GetOrCreate(Type, Arithmetic.Increment(ref typeAddress));
-            ArrayType = links.GetOrCreate(Type, Arithmetic.Increment(ref typeAddress));
-            EmptyArrayType = links.GetOrCreate(Type, Arithmetic.Increment(ref typeAddress));
-            TrueType = links.GetOrCreate(Type, Arithmetic.Increment(ref typeAddress));
-            FalseType = links.GetOrCreate(Type, Arithmetic.Increment(ref typeAddress));
-            NullType = links.GetOrCreate(Type, Arithmetic.Increment(ref typeAddress));
+            typeAddress += TLinkAddress.One;
+            var unicodeSymbolType = links.GetOrCreate(Type, typeAddress);
+            typeAddress += TLinkAddress.One;
+            var unicodeSequenceType = links.GetOrCreate(Type, typeAddress);
+            typeAddress += TLinkAddress.One;
+            DocumentType = links.GetOrCreate(Type, typeAddress);
+            typeAddress += TLinkAddress.One;
+            ObjectType = links.GetOrCreate(Type, typeAddress);
+            typeAddress += TLinkAddress.One;
+            MemberType = links.GetOrCreate(Type, typeAddress);
+            typeAddress += TLinkAddress.One;
+            ValueType = links.GetOrCreate(Type, typeAddress);
+            typeAddress += TLinkAddress.One;
+            StringType = links.GetOrCreate(Type, typeAddress);
+            typeAddress += TLinkAddress.One;
+            EmptyStringType = links.GetOrCreate(Type, typeAddress);
+            typeAddress += TLinkAddress.One;
+            NumberType = links.GetOrCreate(Type, typeAddress);
+            typeAddress += TLinkAddress.One;
+            NegativeNumberType = links.GetOrCreate(Type, typeAddress);
+            typeAddress += TLinkAddress.One;
+            ArrayType = links.GetOrCreate(Type, typeAddress);
+            typeAddress += TLinkAddress.One;
+            EmptyArrayType = links.GetOrCreate(Type, typeAddress);
+            typeAddress += TLinkAddress.One;
+            TrueType = links.GetOrCreate(Type, typeAddress);
+            typeAddress += TLinkAddress.One;
+            FalseType = links.GetOrCreate(Type, typeAddress);
+            typeAddress += TLinkAddress.One;
+            NullType = links.GetOrCreate(Type, typeAddress);
             BalancedVariantConverter = new(links);
             TargetMatcher<TLinkAddress> unicodeSymbolCriterionMatcher = new(Links, unicodeSymbolType);
             TargetMatcher<TLinkAddress> unicodeSequenceCriterionMatcher = new(Links, unicodeSequenceType);

--- a/csharp/Platform.Data.Doublets.Json/JsonExporterCli.cs
+++ b/csharp/Platform.Data.Doublets.Json/JsonExporterCli.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Text.Encodings.Web;
+using System.Numerics;
 using Platform.Data.Doublets.Memory.United.Generic;
 using Platform.IO;
 using System.Text.Json;
@@ -19,7 +20,7 @@ namespace Platform.Data.Doublets.Json
     /// <para></para>
     /// </summary>
     public class JsonExporterCli<TLinkAddress>
-        where TLinkAddress : struct
+        where TLinkAddress : struct, INumber<TLinkAddress>
     {
         /// <summary>
         /// <para>

--- a/csharp/Platform.Data.Doublets.Json/JsonImporterCli.cs
+++ b/csharp/Platform.Data.Doublets.Json/JsonImporterCli.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Numerics;
 using Platform.Data.Doublets.Memory.United.Generic;
 using Platform.IO;
 using System.Text.Json;
@@ -19,7 +20,7 @@ namespace Platform.Data.Doublets.Json
     /// <para></para>
     /// </summary>
     public class JsonImporterCli<TLinkAddress>
-        where TLinkAddress : struct
+        where TLinkAddress : struct, INumber<TLinkAddress>
     {
         /// <summary>
         /// <para>

--- a/csharp/Platform.Data.Doublets.Json/Platform.Data.Doublets.Json.csproj
+++ b/csharp/Platform.Data.Doublets.Json/Platform.Data.Doublets.Json.csproj
@@ -4,7 +4,7 @@
 		<Description>LinksPlatform's Platform.Data.Doublets.Json Class Library</Description>
 		<Copyright>FreePhoenix888</Copyright>
 		<AssemblyTitle>Platform.Data.Doublets.Json</AssemblyTitle>
-		<VersionPrefix>0.1.2</VersionPrefix>
+		<VersionPrefix>0.2.0</VersionPrefix>
 		<Authors>FreePhoenix888</Authors>
 		<TargetFramework>net8</TargetFramework>
 		<AssemblyName>Platform.Data.Doublets.Json</AssemblyName>
@@ -23,7 +23,7 @@
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		<PackageReleaseNotes>Update target framework from net7 to net8.</PackageReleaseNotes>
+		<PackageReleaseNotes>Replace Platform.Numbers library with .NET 8 generic math.</PackageReleaseNotes>
 		<LangVersion>latest</LangVersion>
 	</PropertyGroup>
 


### PR DESCRIPTION
## Summary

This PR implements issue #46 by replacing the Platform.Numbers library with .NET 8 generic math capabilities.

### Changes Made

- **Replaced `Platform.Numbers.Arithmetic.Increment`** with .NET 8 generic math operators (`+=` with `TLinkAddress.One`)
- **Updated generic constraints** to use `INumber<TLinkAddress>` instead of just `struct`
- **Updated imports** to use `System.Numerics` instead of `Platform.Numbers`
- **Applied changes to all relevant classes**:
  - `DefaultJsonStorage<TLinkAddress>`
  - `JsonImporterCli<TLinkAddress>`  
  - `JsonExporterCli<TLinkAddress>`

### Breaking Changes

- **Version bumped to 0.2.0** due to breaking changes in generic constraints
- Classes using `DefaultJsonStorage` now require `TLinkAddress` types that implement `INumber<TLinkAddress>`
- This is compatible with standard numeric types (`uint`, `ulong`, etc.) used in the platform

### Benefits

- **Reduced dependency footprint** - No longer directly depends on Platform.Numbers
- **Better performance** - Uses optimized .NET generic math operations
- **Future-proof** - Leverages modern .NET features
- **Type safety** - Stronger compile-time guarantees for numeric operations

### Testing

- All projects build successfully
- No breaking changes for existing usage with standard numeric types
- Platform.Numbers is still available transitively from other dependencies if needed

Fixes #46

🤖 Generated with [Claude Code](https://claude.ai/code)