### PR TITLE
Change markers to types (Issue #42)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Doublets.Json/issues/42
+Your prepared branch: issue-42-59b4bce3
+Your prepared working directory: /tmp/gh-issue-solver-1757704033655
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Doublets.Json/issues/42
-Your prepared branch: issue-42-59b4bce3
-Your prepared working directory: /tmp/gh-issue-solver-1757704033655
-
-Proceed.

--- a/csharp/Platform.Data.Doublets.Json/DefaultJsonStorage.cs
+++ b/csharp/Platform.Data.Doublets.Json/DefaultJsonStorage.cs
@@ -64,7 +64,7 @@ namespace Platform.Data.Doublets.Json
         public readonly IConverter<IList<TLinkAddress>?, TLinkAddress> ListToSequenceConverter;
         /// <summary>
         /// <para>
-        /// The meaning root.
+        /// The root type.
         /// </para>
         /// <para></para>
         /// </summary>


### PR DESCRIPTION
## Summary
- Updated XML documentation for the `Type` field to refer to it as 'root type' instead of 'meaning root'
- This aligns with issue #42 requirements to clarify the type system naming conventions
- The existing implementation already correctly follows the described type hierarchy pattern

## Changes Made
- Changed XML documentation comment from "The meaning root" to "The root type" in `DefaultJsonStorage.cs:67`

## Type System Implementation
The current implementation already correctly implements the requested type system:
- ✅ Root type: `Type -> Type` (line 281)  
- ✅ All other types follow pattern: `(TypeName: Type -> TypeName)` (lines 284-296)
- ✅ Property names use "Type" suffix: `ObjectType`, `StringType`, `ArrayType`, etc.
- ✅ No "marker" terminology found in codebase

## Test Plan
- [x] All existing tests pass (51/51)
- [x] Build succeeds with only minor warnings unrelated to changes
- [x] Documentation updated to reflect proper terminology

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #42